### PR TITLE
Add patches for 2 kinds of crash

### DIFF
--- a/Patches/Bugfixes/Fix-crash-on-recursive-push.patch
+++ b/Patches/Bugfixes/Fix-crash-on-recursive-push.patch
@@ -1,0 +1,42 @@
+Author: Ben Russell <thematrixeatsyou@gmail.com>
+Date:   Mon Mar 16 21:37:43 2020 +1300
+
+Fix crashes based on an element recursively pushing itself.
+
+The most common case of this is when you duplicate a player-pushable
+element onto a player, which ends up calling the `TouchProc` against
+the source element with a direction equal to the player's movement
+direction.
+
+Another case is performing a `#go idle` in a scroll.
+
+Either way, both of these will no longer crash ZZT.
+
+This does not, however, prevent the player from moving onto a
+duplicator's destination on the same tick that the duplicator fires
+and then the duplicator source ends up moving based on the player's
+move direction. That is a different bug which typically doesn't
+crash the game.
+
+diff --git a/SRC/ELEMENTS.PAS b/SRC/ELEMENTS.PAS
+index 6849c5e..ec2274d 100644
+--- a/SRC/ELEMENTS.PAS
++++ b/SRC/ELEMENTS.PAS
+@@ -899,10 +899,13 @@ procedure ElementPushablePush(x, y: integer; deltaX, deltaY: integer);
+ 			if ((Element = E_SLIDER_NS) and (deltaX = 0)) or ((Element = E_SLIDER_EW) and (deltaY = 0))
+ 				or ElementDefs[Element].Pushable then
+ 			begin
+-				if Board.Tiles[x + deltaX][y + deltaY].Element = E_TRANSPORTER then
+-					ElementTransporterMove(x, y, deltaX, deltaY)
+-				else if Board.Tiles[x + deltaX][y + deltaY].Element <> E_EMPTY then
+-					ElementPushablePush(x + deltaX, y + deltaY, deltaX, deltaY);
++				if Board.Tiles[x + deltaX][y + deltaY].Element = E_TRANSPORTER then begin
++					ElementTransporterMove(x, y, deltaX, deltaY);
++				end else if Board.Tiles[x + deltaX][y + deltaY].Element <> E_EMPTY then begin
++					if (deltaX <> 0) or (deltaY <> 0) then begin
++						ElementPushablePush(x + deltaX, y + deltaY, deltaX, deltaY);
++					end;
++				end;
+ 
+ 				if not ElementDefs[Board.Tiles[x + deltaX][y + deltaY].Element].Walkable
+ 					and ElementDefs[Board.Tiles[x + deltaX][y + deltaY].Element].Destructible

--- a/Patches/Bugfixes/Fix-crash-on-scroll-stat-deletion.patch
+++ b/Patches/Bugfixes/Fix-crash-on-scroll-stat-deletion.patch
@@ -1,0 +1,23 @@
+Author: Ben Russell <thematrixeatsyou@gmail.com>
+Date:   Mon Mar 16 19:56:00 2020 +1300
+
+Fix the crash that happens when you delete the stat from a scroll when
+said stat is no longer there.
+
+This allows the use of `#become` and `/dir`, of which the latter can
+preserve the scroll if it manages to actually move.
+
+--- a/SRC/ELEMENTS.PAS
++++ b/SRC/ELEMENTS.PAS
+@@ -1036,7 +1036,10 @@ procedure ElementScrollTouch(x, y: integer; unkArg1: integer; var deltaX, deltaY
+ 			OopExecute(statId, DataPos, 'Scroll');
+ 		end;
+ 
+-		RemoveStat(GetStatIdAt(x, y));
++		statId := GetStatIdAt(x, y);
++		if statId <> -1 then begin
++			RemoveStat(statId);
++		end;
+ 	end;
+ 
+ procedure ElementKeyTouch(x, y: integer; unkArg1: integer; var deltaX, deltaY: integer);


### PR DESCRIPTION
These have been cherry-picked as individual patches from my personal codebase, compared against master at 5ae20a9 .

Test cases:

- Set up a duplicator. Source should be a boulder. Destination should be somewhere the player can walk into. Start the game, walk into the destination, wait for the duplicator to fire.
- Make a scroll with `#go idle` in it. Start the game, touch the scroll.
- Make a scroll with `#become ammo` in it. Start the game, touch the scroll.
- Make a scroll with `/opp seek` in it. Start the game, touch the scroll.