### PR TITLE
No Flashing Messages Patch

### DIFF
--- a/Patches/Cheats/Cheat-Light.patch
+++ b/Patches/Cheats/Cheat-Light.patch
@@ -1,0 +1,13 @@
+diff -Nrup src.orig/SRC/GAME.PAS src.new/SRC/GAME.PAS
+--- src.orig/SRC/GAME.PAS	2020-03-23 10:36:19.502158100 -0700
++++ src.new/SRC/GAME.PAS	2020-03-23 11:42:07.677201900 -0700
+@@ -1394,6 +1394,9 @@ procedure GameDebugPrompt;
+ 		else if input = 'DARK' then begin
+ 			Board.Info.IsDark := toggle;
+ 			TransitionDrawToBoard;
++		end else if input = 'LIGHT' then begin
++			Board.Info.IsDark := false;
++			TransitionDrawToBoard;
+ 		end else if input = 'ZAP' then begin
+ 			for i := 0 to 3 do begin
+ 				BoardDamageTile(Board.Stats[0].X + NeighborDeltaX[i], Board.Stats[0].Y + NeighborDeltaY[i]);

--- a/Patches/Tweaks/No-flashing-messages.patch
+++ b/Patches/Tweaks/No-flashing-messages.patch
@@ -1,0 +1,18 @@
+Name: No Flashing Messages
+Author: Dr. Dos <doctordos@gmail.com>
+
+Force flashing colors in messages to be solid green. This looks lifeless but
+ensures messages captures in screenshots are easily readable.
+
+diff -Nrup src.orig/SRC/ELEMENTS.PAS src.new/SRC/ELEMENTS.PAS
+--- src.orig/SRC/ELEMENTS.PAS	2020-03-23 10:36:19.501208800 -0700
++++ src.new/SRC/ELEMENTS.PAS	2020-03-23 10:37:09.752852600 -0700
+@@ -64,7 +64,7 @@ procedure ElementMessageTimerTick(statId
+ 		with Board.Stats[statId] do begin
+ 			case X of
+ 				0: begin
+-					VideoWriteText((60 - Length(Board.Info.Message)) div 2, 24, 9 + (P2 mod 7), ' '+Board.Info.Message+' ');
++					VideoWriteText((60 - Length(Board.Info.Message)) div 2, 24, 10, ' '+Board.Info.Message+' ');
+ 					P2 := P2 - 1;
+ 					if P2 <= 0 then begin
+ 						RemoveStat(statId);

--- a/Patches/Tweaks/No-flashing-messages.patch
+++ b/Patches/Tweaks/No-flashing-messages.patch
@@ -2,7 +2,7 @@ Name: No Flashing Messages
 Author: Dr. Dos <doctordos@gmail.com>
 
 Force flashing colors in messages to be solid green. This looks lifeless but
-ensures messages captures in screenshots are easily readable.
+ensures messages captured in screenshots are easily readable.
 
 diff -Nrup src.orig/SRC/ELEMENTS.PAS src.new/SRC/ELEMENTS.PAS
 --- src.orig/SRC/ELEMENTS.PAS	2020-03-23 10:36:19.501208800 -0700


### PR DESCRIPTION
Make messages solid green instead of constantly changing colors to assist in ensuring readable text in screenshots.